### PR TITLE
feat: PR #3 – DataAccess & EF Core (DbContext, migrations, repository, wiring)

### DIFF
--- a/HRMS.API/HRMS.API.csproj
+++ b/HRMS.API/HRMS.API.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\HRMS.Services\HRMS.Services.csproj" />
     <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
+    <ProjectReference Include="..\HRMS.DataAccess\HRMS.DataAccess.csproj" />
   </ItemGroup>
 </Project>

--- a/HRMS.API/Program.cs
+++ b/HRMS.API/Program.cs
@@ -1,7 +1,28 @@
+using HRMS.DataAccess;
+using HRMS.DataAccess.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+                      ?? "Server=(localdb)\\MSSQLLocalDB;Database=HRMSDb;Trusted_Connection=True;TrustServerCertificate=True;";
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
 
 var app = builder.Build();
 
 app.MapGet("/", () => "HRMS API");
+
+app.MapGet("/health/db", async (AppDbContext context) =>
+{
+    var canConnect = await context.Database.CanConnectAsync();
+    return canConnect
+        ? Results.Ok(new { status = "Healthy" })
+        : Results.Problem("Database connection failed.", statusCode: StatusCodes.Status503ServiceUnavailable);
+});
 
 app.Run();

--- a/HRMS.API/appsettings.Development.json
+++ b/HRMS.API/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HRMSDb;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HRMS.API/appsettings.json
+++ b/HRMS.API/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HRMSDb;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HRMS.DataAccess/AppDbContext.cs
+++ b/HRMS.DataAccess/AppDbContext.cs
@@ -1,0 +1,22 @@
+using HRMS.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.DataAccess;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Department> Departments => Set<Department>();
+    public DbSet<Employee> Employees => Set<Employee>();
+    public DbSet<LeaveBalance> LeaveBalances => Set<LeaveBalance>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/HRMS.DataAccess/Class1.cs
+++ b/HRMS.DataAccess/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HRMS.DataAccess;
-
-public class Class1
-{
-
-}

--- a/HRMS.DataAccess/Configurations/DepartmentConfiguration.cs
+++ b/HRMS.DataAccess/Configurations/DepartmentConfiguration.cs
@@ -1,0 +1,25 @@
+using HRMS.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HRMS.DataAccess.Configurations;
+
+public class DepartmentConfiguration : IEntityTypeConfiguration<Department>
+{
+    public void Configure(EntityTypeBuilder<Department> builder)
+    {
+        builder.ToTable("Departments");
+
+        builder.HasKey(d => d.Id);
+
+        builder.Property(d => d.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(d => d.Name)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.HasIndex(d => d.Name)
+            .IsUnique();
+    }
+}

--- a/HRMS.DataAccess/Configurations/EmployeeConfiguration.cs
+++ b/HRMS.DataAccess/Configurations/EmployeeConfiguration.cs
@@ -1,0 +1,41 @@
+using HRMS.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HRMS.DataAccess.Configurations;
+
+public class EmployeeConfiguration : IEntityTypeConfiguration<Employee>
+{
+    public void Configure(EntityTypeBuilder<Employee> builder)
+    {
+        builder.ToTable("Employees");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.EmpNo)
+            .IsRequired()
+            .HasMaxLength(32);
+
+        builder.HasIndex(e => e.EmpNo)
+            .IsUnique();
+
+        builder.Property(e => e.FullName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(e => e.Email)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(e => e.HireDate)
+            .IsRequired();
+
+        builder.HasOne(e => e.Department)
+            .WithMany()
+            .HasForeignKey(e => e.DepartmentId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/HRMS.DataAccess/Configurations/LeaveBalanceConfiguration.cs
+++ b/HRMS.DataAccess/Configurations/LeaveBalanceConfiguration.cs
@@ -1,0 +1,34 @@
+using HRMS.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HRMS.DataAccess.Configurations;
+
+public class LeaveBalanceConfiguration : IEntityTypeConfiguration<LeaveBalance>
+{
+    public void Configure(EntityTypeBuilder<LeaveBalance> builder)
+    {
+        builder.ToTable("LeaveBalances");
+
+        builder.HasKey(l => l.Id);
+
+        builder.Property(l => l.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(l => l.EmpNo)
+            .IsRequired()
+            .HasMaxLength(32);
+
+        builder.HasIndex(l => l.EmpNo)
+            .IsUnique();
+
+        builder.Property(l => l.Annual)
+            .IsRequired();
+
+        builder.Property(l => l.Sick)
+            .IsRequired();
+
+        builder.Property(l => l.Unpaid)
+            .IsRequired();
+    }
+}

--- a/HRMS.DataAccess/DesignTimeDbContextFactory.cs
+++ b/HRMS.DataAccess/DesignTimeDbContextFactory.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace HRMS.DataAccess;
+
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        var configuration = BuildConfiguration();
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+                               ?? "Server=(localdb)\\MSSQLLocalDB;Database=HRMSDb;Trusted_Connection=True;TrustServerCertificate=True;";
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseSqlServer(connectionString);
+
+        return new AppDbContext(optionsBuilder.Options);
+    }
+
+    private static IConfiguration BuildConfiguration()
+    {
+        var basePath = Directory.GetCurrentDirectory();
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        IConfigurationRoot configuration = BuildConfigurationForPath(basePath, environment);
+
+        if (!string.IsNullOrWhiteSpace(configuration.GetConnectionString("DefaultConnection")))
+        {
+            return configuration;
+        }
+
+        var apiPath = Path.Combine(basePath, "..", "HRMS.API");
+        return BuildConfigurationForPath(apiPath, environment);
+    }
+
+    private static IConfigurationRoot BuildConfigurationForPath(string basePath, string? environment)
+    {
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(basePath)
+            .AddJsonFile("appsettings.json", optional: true);
+
+        if (!string.IsNullOrWhiteSpace(environment))
+        {
+            builder.AddJsonFile($"appsettings.{environment}.json", optional: true);
+        }
+
+        builder.AddEnvironmentVariables();
+
+        return builder.Build();
+    }
+}

--- a/HRMS.DataAccess/HRMS.DataAccess.csproj
+++ b/HRMS.DataAccess/HRMS.DataAccess.csproj
@@ -1,13 +1,26 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
-  </ItemGroup>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/HRMS.DataAccess/Migrations/20240601000000_InitialCreate.cs
+++ b/HRMS.DataAccess/Migrations/20240601000000_InitialCreate.cs
@@ -1,0 +1,103 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HRMS.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Departments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Departments", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeaveBalances",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    EmpNo = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    Annual = table.Column<int>(type: "int", nullable: false),
+                    Sick = table.Column<int>(type: "int", nullable: false),
+                    Unpaid = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeaveBalances", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    EmpNo = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    FullName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    HireDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DepartmentId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Employees_Departments_DepartmentId",
+                        column: x => x.DepartmentId,
+                        principalTable: "Departments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Departments_Name",
+                table: "Departments",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_DepartmentId",
+                table: "Employees",
+                column: "DepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_EmpNo",
+                table: "Employees",
+                column: "EmpNo",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeaveBalances_EmpNo",
+                table: "LeaveBalances",
+                column: "EmpNo",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Employees");
+
+            migrationBuilder.DropTable(
+                name: "LeaveBalances");
+
+            migrationBuilder.DropTable(
+                name: "Departments");
+        }
+    }
+}

--- a/HRMS.DataAccess/Migrations/AppDbContextModelSnapshot.cs
+++ b/HRMS.DataAccess/Migrations/AppDbContextModelSnapshot.cs
@@ -1,0 +1,126 @@
+using System;
+using HRMS.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace HRMS.DataAccess.Migrations
+{
+    [DbContext(typeof(AppDbContext))]
+    partial class AppDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.6")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("HRMS.Models.Entities.Department", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Name")
+                        .IsUnique();
+
+                    b.ToTable("Departments");
+                });
+
+            modelBuilder.Entity("HRMS.Models.Entities.Employee", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("DepartmentId")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("EmpNo")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("nvarchar(32)");
+
+                    b.Property<string>("FullName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<DateTime>("HireDate")
+                        .HasColumnType("datetime2");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DepartmentId");
+
+                    b.HasIndex("EmpNo")
+                        .IsUnique();
+
+                    b.ToTable("Employees");
+                });
+
+            modelBuilder.Entity("HRMS.Models.Entities.LeaveBalance", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("Annual")
+                        .HasColumnType("int");
+
+                    b.Property<string>("EmpNo")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("nvarchar(32)");
+
+                    b.Property<int>("Sick")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Unpaid")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EmpNo")
+                        .IsUnique();
+
+                    b.ToTable("LeaveBalances");
+                });
+
+            modelBuilder.Entity("HRMS.Models.Entities.Employee", b =>
+                {
+                    b.HasOne("HRMS.Models.Entities.Department", "Department")
+                        .WithMany()
+                        .HasForeignKey("DepartmentId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Department");
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/HRMS.DataAccess/Repositories/GenericRepository.cs
+++ b/HRMS.DataAccess/Repositories/GenericRepository.cs
@@ -1,0 +1,67 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.DataAccess.Repositories;
+
+public class GenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly AppDbContext _context;
+    private readonly DbSet<T> _dbSet;
+
+    public GenericRepository(AppDbContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<T>();
+    }
+
+    public async Task<List<T>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.AsNoTracking().ToListAsync(cancellationToken);
+    }
+
+    public async Task<T?> GetByIdAsync(object id, CancellationToken cancellationToken = default)
+    {
+        var entry = await _dbSet.FindAsync(new object?[] { id }, cancellationToken);
+        return entry;
+    }
+
+    public async Task<List<T>> FindAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.AsNoTracking().Where(predicate).ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        await _dbSet.AddAsync(entity, cancellationToken);
+    }
+
+    public async Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default)
+    {
+        await _dbSet.AddRangeAsync(entities, cancellationToken);
+    }
+
+    public void Update(T entity)
+    {
+        _dbSet.Update(entity);
+    }
+
+    public void Remove(T entity)
+    {
+        _dbSet.Remove(entity);
+    }
+
+    public void RemoveRange(IEnumerable<T> entities)
+    {
+        _dbSet.RemoveRange(entities);
+    }
+
+    public IQueryable<T> Query()
+    {
+        return _dbSet.AsQueryable();
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/HRMS.DataAccess/Repositories/IGenericRepository.cs
+++ b/HRMS.DataAccess/Repositories/IGenericRepository.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+
+namespace HRMS.DataAccess.Repositories;
+
+public interface IGenericRepository<T> where T : class
+{
+    Task<List<T>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<T?> GetByIdAsync(object id, CancellationToken cancellationToken = default);
+    Task<List<T>> FindAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);
+    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
+    void Update(T entity);
+    void Remove(T entity);
+    void RemoveRange(IEnumerable<T> entities);
+    IQueryable<T> Query();
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codex-hrms-clean-architecture
 
-Clean Architecture HRMS demo with .NET 8
+Clean Architecture HRMS demo with .NET 8.
 
 ## Solution Layout
 - **HRMS.Models** (Class Library)
@@ -9,6 +9,29 @@ Clean Architecture HRMS demo with .NET 8
 - **HRMS.API** (ASP.NET Core Web API)
 - **HRMS.UI** (ASP.NET Core MVC)
 - **HRMS.Tests** (xUnit)
+
+## Data Access & EF Core
+- `HRMS.DataAccess` exposes `AppDbContext`, fluent entity configurations, and a reusable `IGenericRepository<T>`/`GenericRepository<T>` pair.
+- Entity Framework Core is configured for SQL Server and wired into `HRMS.API` via dependency injection.
+- A database health probe is available at `GET /health/db` (returns HTTP 200 when the database connection succeeds).
+
+### Packages
+The data access project references the following EF Core packages:
+- `Microsoft.EntityFrameworkCore`
+- `Microsoft.EntityFrameworkCore.SqlServer`
+- `Microsoft.EntityFrameworkCore.Design`
+- `Microsoft.EntityFrameworkCore.Tools`
+
+### Migrations
+Create or update migrations from the solution root (files only, no database update required):
+
+```bash
+# Add a new migration
+dotnet ef migrations add <MigrationName> -p HRMS.DataAccess -s HRMS.API
+
+# Apply migrations to the configured database
+dotnet ef database update -p HRMS.DataAccess -s HRMS.API
+```
 
 ## Running
 


### PR DESCRIPTION
## Summary
- add the Entity Framework Core data access project structure, DbContext, and fluent configurations for the existing models
- create the design-time DbContext factory, generic repository abstraction/implementation, and the InitialCreate migration artifacts
- wire the DbContext and repository into the API (including a `/health/db` endpoint) and document EF packages, migration commands, and health check details

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8dd58d9a88333ac6ba04ebe110916