### PR TITLE
feat: PR #4 – Services layer (CRUD services, DTO mapping, DI, test scaffolds)

### DIFF
--- a/HRMS.API/Program.cs
+++ b/HRMS.API/Program.cs
@@ -1,5 +1,7 @@
 using HRMS.DataAccess;
 using HRMS.DataAccess.Repositories;
+using HRMS.Services;
+using HRMS.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +14,9 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(connectionString));
 
 builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+builder.Services.AddScoped<IDepartmentService, DepartmentService>();
+builder.Services.AddScoped<IEmployeeService, EmployeeService>();
+builder.Services.AddScoped<ILeaveBalanceService, LeaveBalanceService>();
 
 var app = builder.Build();
 

--- a/HRMS.Models/DTOs/CreateDepartmentDto.cs
+++ b/HRMS.Models/DTOs/CreateDepartmentDto.cs
@@ -1,0 +1,6 @@
+namespace HRMS.Models.DTOs;
+
+public class CreateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/HRMS.Models/DTOs/CreateLeaveBalanceDto.cs
+++ b/HRMS.Models/DTOs/CreateLeaveBalanceDto.cs
@@ -1,9 +1,7 @@
 namespace HRMS.Models.DTOs;
 
-public class LeaveBalanceDto
+public class CreateLeaveBalanceDto
 {
-    public int Id { get; set; }
-
     public string EmpNo { get; set; } = string.Empty;
 
     public int Annual { get; set; }

--- a/HRMS.Models/DTOs/DepartmentDto.cs
+++ b/HRMS.Models/DTOs/DepartmentDto.cs
@@ -1,0 +1,8 @@
+namespace HRMS.Models.DTOs;
+
+public class DepartmentDto
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}

--- a/HRMS.Models/DTOs/PagedRequest.cs
+++ b/HRMS.Models/DTOs/PagedRequest.cs
@@ -1,0 +1,34 @@
+namespace HRMS.Models.DTOs;
+
+public class PagedRequest
+{
+    public const int DefaultPage = 1;
+    public const int DefaultPageSize = 10;
+    public const int MaxPageSize = 100;
+
+    private int _page = DefaultPage;
+    private int _pageSize = DefaultPageSize;
+
+    public int Page
+    {
+        get => _page;
+        set => _page = value < 1 ? DefaultPage : value;
+    }
+
+    public int PageSize
+    {
+        get => _pageSize;
+        set
+        {
+            if (value < 1)
+            {
+                _pageSize = DefaultPageSize;
+                return;
+            }
+
+            _pageSize = Math.Min(value, MaxPageSize);
+        }
+    }
+
+    public string? SearchTerm { get; set; }
+}

--- a/HRMS.Models/DTOs/UpdateDepartmentDto.cs
+++ b/HRMS.Models/DTOs/UpdateDepartmentDto.cs
@@ -1,0 +1,6 @@
+namespace HRMS.Models.DTOs;
+
+public class UpdateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/HRMS.Models/DTOs/UpdateLeaveBalanceDto.cs
+++ b/HRMS.Models/DTOs/UpdateLeaveBalanceDto.cs
@@ -1,11 +1,7 @@
 namespace HRMS.Models.DTOs;
 
-public class LeaveBalanceDto
+public class UpdateLeaveBalanceDto
 {
-    public int Id { get; set; }
-
-    public string EmpNo { get; set; } = string.Empty;
-
     public int Annual { get; set; }
 
     public int Sick { get; set; }

--- a/HRMS.Services/Class1.cs
+++ b/HRMS.Services/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HRMS.Services;
-
-public class Class1
-{
-
-}

--- a/HRMS.Services/DepartmentService.cs
+++ b/HRMS.Services/DepartmentService.cs
@@ -1,0 +1,154 @@
+using HRMS.DataAccess.Repositories;
+using HRMS.Models.DTOs;
+using HRMS.Models.Entities;
+using HRMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.Services;
+
+public class DepartmentService : IDepartmentService
+{
+    private readonly IGenericRepository<Department> _departmentRepository;
+
+    public DepartmentService(IGenericRepository<Department> departmentRepository)
+    {
+        _departmentRepository = departmentRepository;
+    }
+
+    public async Task<PagedResult<DepartmentDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+    {
+        var paging = request ?? new PagedRequest();
+        var query = _departmentRepository.Query().AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(paging.SearchTerm))
+        {
+            var term = paging.SearchTerm.Trim();
+            query = query.Where(department => EF.Functions.Like(department.Name, $"%{term}%"));
+        }
+
+        query = query.OrderBy(department => department.Name);
+
+        var total = await query.CountAsync(cancellationToken);
+        var departments = await query
+            .Skip((paging.Page - 1) * paging.PageSize)
+            .Take(paging.PageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<DepartmentDto>
+        {
+            Items = departments.Select(MapToDto).ToList(),
+            Total = total,
+            Page = paging.Page,
+            PageSize = paging.PageSize
+        };
+    }
+
+    public async Task<DepartmentDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var department = await _departmentRepository
+            .Query()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        return department is null ? null : MapToDto(department);
+    }
+
+    public async Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        var name = NormalizeName(dto.Name);
+
+        await EnsureNameIsUniqueAsync(name, cancellationToken);
+
+        var department = new Department
+        {
+            Name = name
+        };
+
+        await _departmentRepository.AddAsync(department, cancellationToken);
+        await _departmentRepository.SaveChangesAsync(cancellationToken);
+
+        return MapToDto(department);
+    }
+
+    public async Task<DepartmentDto?> UpdateAsync(int id, UpdateDepartmentDto dto, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+        ArgumentNullException.ThrowIfNull(dto);
+        var name = NormalizeName(dto.Name);
+
+        var department = await _departmentRepository
+            .Query()
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        if (department is null)
+        {
+            return null;
+        }
+
+        if (!string.Equals(department.Name, name, StringComparison.OrdinalIgnoreCase))
+        {
+            await EnsureNameIsUniqueAsync(name, cancellationToken);
+        }
+
+        department.Name = name;
+        _departmentRepository.Update(department);
+        await _departmentRepository.SaveChangesAsync(cancellationToken);
+
+        return MapToDto(department);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var department = await _departmentRepository.GetByIdAsync(id, cancellationToken);
+        if (department is null)
+        {
+            return false;
+        }
+
+        _departmentRepository.Remove(department);
+        await _departmentRepository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private static DepartmentDto MapToDto(Department department) => new()
+    {
+        Id = department.Id,
+        Name = department.Name
+    };
+
+    private static string NormalizeName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Department name is required.", nameof(name));
+        }
+
+        return name.Trim();
+    }
+
+    private static void ValidateId(int id)
+    {
+        if (id <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(id), "The identifier must be greater than zero.");
+        }
+    }
+
+    private async Task EnsureNameIsUniqueAsync(string name, CancellationToken cancellationToken)
+    {
+        var normalizedName = name.ToUpperInvariant();
+        var exists = await _departmentRepository
+            .Query()
+            .AnyAsync(entity => entity.Name.ToUpper() == normalizedName, cancellationToken);
+
+        if (exists)
+        {
+            throw new InvalidOperationException($"Department '{name}' already exists.");
+        }
+    }
+}

--- a/HRMS.Services/EmployeeService.cs
+++ b/HRMS.Services/EmployeeService.cs
@@ -1,0 +1,223 @@
+using HRMS.DataAccess.Repositories;
+using HRMS.Models.DTOs;
+using HRMS.Models.Entities;
+using HRMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.Services;
+
+public class EmployeeService : IEmployeeService
+{
+    private readonly IGenericRepository<Employee> _employeeRepository;
+    private readonly IGenericRepository<Department> _departmentRepository;
+
+    public EmployeeService(
+        IGenericRepository<Employee> employeeRepository,
+        IGenericRepository<Department> departmentRepository)
+    {
+        _employeeRepository = employeeRepository;
+        _departmentRepository = departmentRepository;
+    }
+
+    public async Task<PagedResult<EmployeeDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+    {
+        var paging = request ?? new PagedRequest();
+
+        var query = _employeeRepository
+            .Query()
+            .Include(employee => employee.Department)
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(paging.SearchTerm))
+        {
+            var term = $"%{paging.SearchTerm.Trim()}%";
+            query = query.Where(employee =>
+                EF.Functions.Like(employee.FullName, term) ||
+                EF.Functions.Like(employee.EmpNo, term) ||
+                EF.Functions.Like(employee.Email, term));
+        }
+
+        query = query.OrderBy(employee => employee.FullName);
+
+        var total = await query.CountAsync(cancellationToken);
+        var employees = await query
+            .Skip((paging.Page - 1) * paging.PageSize)
+            .Take(paging.PageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<EmployeeDto>
+        {
+            Items = employees.Select(MapToDto).ToList(),
+            Total = total,
+            Page = paging.Page,
+            PageSize = paging.PageSize
+        };
+    }
+
+    public async Task<EmployeeDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var employee = await _employeeRepository
+            .Query()
+            .Include(entity => entity.Department)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        return employee is null ? null : MapToDto(employee);
+    }
+
+    public async Task<EmployeeDto> CreateAsync(CreateEmployeeDto dto, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        var normalizedEmpNo = NormalizeRequiredString(dto.EmpNo, nameof(dto.EmpNo));
+        var fullName = NormalizeRequiredString(dto.FullName, nameof(dto.FullName));
+        var email = NormalizeRequiredString(dto.Email, nameof(dto.Email));
+        ValidateEmail(email);
+        ValidateHireDate(dto.HireDate);
+
+        await EnsureEmployeeNumberIsUniqueAsync(normalizedEmpNo, cancellationToken);
+        await EnsureDepartmentExistsAsync(dto.DepartmentId, cancellationToken);
+
+        var employee = new Employee
+        {
+            EmpNo = normalizedEmpNo,
+            FullName = fullName,
+            Email = email,
+            DepartmentId = dto.DepartmentId,
+            HireDate = dto.HireDate
+        };
+
+        await _employeeRepository.AddAsync(employee, cancellationToken);
+        await _employeeRepository.SaveChangesAsync(cancellationToken);
+
+        return await GetByIdAsync(employee.Id, cancellationToken)
+               ?? MapToDto(employee);
+    }
+
+    public async Task<EmployeeDto?> UpdateAsync(int id, UpdateEmployeeDto dto, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var employee = await _employeeRepository
+            .Query()
+            .Include(entity => entity.Department)
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        if (employee is null)
+        {
+            return null;
+        }
+
+        var fullName = NormalizeRequiredString(dto.FullName, nameof(dto.FullName));
+        var email = NormalizeRequiredString(dto.Email, nameof(dto.Email));
+        ValidateEmail(email);
+        ValidateHireDate(dto.HireDate);
+
+        if (employee.DepartmentId != dto.DepartmentId)
+        {
+            var department = await EnsureDepartmentExistsAsync(dto.DepartmentId, cancellationToken);
+            employee.DepartmentId = department.Id;
+            employee.Department = department;
+        }
+
+        employee.FullName = fullName;
+        employee.Email = email;
+        employee.HireDate = dto.HireDate;
+
+        _employeeRepository.Update(employee);
+        await _employeeRepository.SaveChangesAsync(cancellationToken);
+
+        return await GetByIdAsync(id, cancellationToken)
+               ?? MapToDto(employee);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var employee = await _employeeRepository.GetByIdAsync(id, cancellationToken);
+        if (employee is null)
+        {
+            return false;
+        }
+
+        _employeeRepository.Remove(employee);
+        await _employeeRepository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private async Task EnsureEmployeeNumberIsUniqueAsync(string empNo, CancellationToken cancellationToken)
+    {
+        var normalized = empNo.ToUpperInvariant();
+        var exists = await _employeeRepository
+            .Query()
+            .AnyAsync(employee => employee.EmpNo.ToUpper() == normalized, cancellationToken);
+
+        if (exists)
+        {
+            throw new InvalidOperationException($"Employee number '{empNo}' already exists.");
+        }
+    }
+
+    private async Task<Department> EnsureDepartmentExistsAsync(int departmentId, CancellationToken cancellationToken)
+    {
+        if (departmentId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(departmentId), "Department is required.");
+        }
+
+        var department = await _departmentRepository.GetByIdAsync(departmentId, cancellationToken);
+        if (department is null)
+        {
+            throw new InvalidOperationException($"Department '{departmentId}' was not found.");
+        }
+
+        return department;
+    }
+
+    private static void ValidateId(int id)
+    {
+        if (id <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(id), "The identifier must be greater than zero.");
+        }
+    }
+
+    private static string NormalizeRequiredString(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+        }
+
+        return value.Trim();
+    }
+
+    private static void ValidateEmail(string email)
+    {
+        if (!email.Contains('@', StringComparison.Ordinal) || email.EndsWith('@', StringComparison.Ordinal))
+        {
+            throw new ArgumentException("A valid email address is required.", nameof(email));
+        }
+    }
+
+    private static void ValidateHireDate(DateTime hireDate)
+    {
+        if (hireDate == default)
+        {
+            throw new ArgumentException("Hire date must be specified.", nameof(hireDate));
+        }
+    }
+
+    private static EmployeeDto MapToDto(Employee employee) => new()
+    {
+        Id = employee.Id,
+        EmpNo = employee.EmpNo,
+        FullName = employee.FullName,
+        Email = employee.Email,
+        HireDate = employee.HireDate,
+        DepartmentName = employee.Department?.Name ?? string.Empty
+    };
+}

--- a/HRMS.Services/Interfaces/IDepartmentService.cs
+++ b/HRMS.Services/Interfaces/IDepartmentService.cs
@@ -1,0 +1,16 @@
+using HRMS.Models.DTOs;
+
+namespace HRMS.Services.Interfaces;
+
+public interface IDepartmentService
+{
+    Task<PagedResult<DepartmentDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default);
+
+    Task<DepartmentDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto, CancellationToken cancellationToken = default);
+
+    Task<DepartmentDto?> UpdateAsync(int id, UpdateDepartmentDto dto, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/HRMS.Services/Interfaces/IEmployeeService.cs
+++ b/HRMS.Services/Interfaces/IEmployeeService.cs
@@ -1,0 +1,16 @@
+using HRMS.Models.DTOs;
+
+namespace HRMS.Services.Interfaces;
+
+public interface IEmployeeService
+{
+    Task<PagedResult<EmployeeDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default);
+
+    Task<EmployeeDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<EmployeeDto> CreateAsync(CreateEmployeeDto dto, CancellationToken cancellationToken = default);
+
+    Task<EmployeeDto?> UpdateAsync(int id, UpdateEmployeeDto dto, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/HRMS.Services/Interfaces/ILeaveBalanceService.cs
+++ b/HRMS.Services/Interfaces/ILeaveBalanceService.cs
@@ -1,0 +1,18 @@
+using HRMS.Models.DTOs;
+
+namespace HRMS.Services.Interfaces;
+
+public interface ILeaveBalanceService
+{
+    Task<PagedResult<LeaveBalanceDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default);
+
+    Task<LeaveBalanceDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<LeaveBalanceDto?> GetByEmployeeNumberAsync(string empNo, CancellationToken cancellationToken = default);
+
+    Task<LeaveBalanceDto> CreateAsync(CreateLeaveBalanceDto dto, CancellationToken cancellationToken = default);
+
+    Task<LeaveBalanceDto?> UpdateAsync(int id, UpdateLeaveBalanceDto dto, CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/HRMS.Services/LeaveBalanceService.cs
+++ b/HRMS.Services/LeaveBalanceService.cs
@@ -1,0 +1,178 @@
+using HRMS.DataAccess.Repositories;
+using HRMS.Models.DTOs;
+using HRMS.Models.Entities;
+using HRMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.Services;
+
+public class LeaveBalanceService : ILeaveBalanceService
+{
+    private readonly IGenericRepository<LeaveBalance> _leaveBalanceRepository;
+
+    public LeaveBalanceService(IGenericRepository<LeaveBalance> leaveBalanceRepository)
+    {
+        _leaveBalanceRepository = leaveBalanceRepository;
+    }
+
+    public async Task<PagedResult<LeaveBalanceDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+    {
+        var paging = request ?? new PagedRequest();
+        var query = _leaveBalanceRepository.Query().AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(paging.SearchTerm))
+        {
+            var term = $"%{paging.SearchTerm.Trim()}%";
+            query = query.Where(balance => EF.Functions.Like(balance.EmpNo, term));
+        }
+
+        query = query.OrderBy(balance => balance.EmpNo);
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .Skip((paging.Page - 1) * paging.PageSize)
+            .Take(paging.PageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<LeaveBalanceDto>
+        {
+            Items = items.Select(MapToDto).ToList(),
+            Total = total,
+            Page = paging.Page,
+            PageSize = paging.PageSize
+        };
+    }
+
+    public async Task<LeaveBalanceDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var balance = await _leaveBalanceRepository
+            .Query()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        return balance is null ? null : MapToDto(balance);
+    }
+
+    public async Task<LeaveBalanceDto?> GetByEmployeeNumberAsync(string empNo, CancellationToken cancellationToken = default)
+    {
+        var normalizedEmpNo = NormalizeEmployeeNumber(empNo);
+
+        var balance = await _leaveBalanceRepository
+            .Query()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(entity => entity.EmpNo.ToUpper() == normalizedEmpNo, cancellationToken);
+
+        return balance is null ? null : MapToDto(balance);
+    }
+
+    public async Task<LeaveBalanceDto> CreateAsync(CreateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+        var empNo = NormalizeEmployeeNumber(dto.EmpNo);
+        ValidateLeaveValues(dto.Annual, dto.Sick, dto.Unpaid);
+
+        await EnsureEmployeeNumberIsUniqueAsync(empNo, cancellationToken);
+
+        var balance = new LeaveBalance
+        {
+            EmpNo = empNo,
+            Annual = dto.Annual,
+            Sick = dto.Sick,
+            Unpaid = dto.Unpaid
+        };
+
+        await _leaveBalanceRepository.AddAsync(balance, cancellationToken);
+        await _leaveBalanceRepository.SaveChangesAsync(cancellationToken);
+
+        return MapToDto(balance);
+    }
+
+    public async Task<LeaveBalanceDto?> UpdateAsync(int id, UpdateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+        ArgumentNullException.ThrowIfNull(dto);
+        ValidateLeaveValues(dto.Annual, dto.Sick, dto.Unpaid);
+
+        var balance = await _leaveBalanceRepository
+            .Query()
+            .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+
+        if (balance is null)
+        {
+            return null;
+        }
+
+        balance.Annual = dto.Annual;
+        balance.Sick = dto.Sick;
+        balance.Unpaid = dto.Unpaid;
+
+        _leaveBalanceRepository.Update(balance);
+        await _leaveBalanceRepository.SaveChangesAsync(cancellationToken);
+
+        return MapToDto(balance);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+
+        var balance = await _leaveBalanceRepository.GetByIdAsync(id, cancellationToken);
+        if (balance is null)
+        {
+            return false;
+        }
+
+        _leaveBalanceRepository.Remove(balance);
+        await _leaveBalanceRepository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private static string NormalizeEmployeeNumber(string empNo)
+    {
+        if (string.IsNullOrWhiteSpace(empNo))
+        {
+            throw new ArgumentException("Employee number is required.", nameof(empNo));
+        }
+
+        return empNo.Trim().ToUpperInvariant();
+    }
+
+    private async Task EnsureEmployeeNumberIsUniqueAsync(string empNo, CancellationToken cancellationToken)
+    {
+        var exists = await _leaveBalanceRepository
+            .Query()
+            .AnyAsync(entity => entity.EmpNo.ToUpper() == empNo, cancellationToken);
+
+        if (exists)
+        {
+            throw new InvalidOperationException($"Leave balance for employee '{empNo}' already exists.");
+        }
+    }
+
+    private static void ValidateLeaveValues(int annual, int sick, int unpaid)
+    {
+        if (annual < 0 || sick < 0 || unpaid < 0)
+        {
+            throw new ArgumentOutOfRangeException("Leave balances cannot be negative.");
+        }
+    }
+
+    private static void ValidateId(int id)
+    {
+        if (id <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(id), "The identifier must be greater than zero.");
+        }
+    }
+
+    private static LeaveBalanceDto MapToDto(LeaveBalance balance) => new()
+    {
+        Id = balance.Id,
+        EmpNo = balance.EmpNo,
+        Annual = balance.Annual,
+        Sick = balance.Sick,
+        Unpaid = balance.Unpaid
+    };
+}

--- a/HRMS.Tests/HRMS.Tests.csproj
+++ b/HRMS.Tests/HRMS.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\HRMS.Services\HRMS.Services.csproj" />
     <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
+    <ProjectReference Include="..\HRMS.DataAccess\HRMS.DataAccess.csproj" />
   </ItemGroup>
 
 </Project>

--- a/HRMS.Tests/Services_SmokeTests.cs
+++ b/HRMS.Tests/Services_SmokeTests.cs
@@ -1,0 +1,52 @@
+using HRMS.DataAccess;
+using HRMS.DataAccess.Repositories;
+using HRMS.Models.DTOs;
+using HRMS.Models.Entities;
+using HRMS.Services;
+using HRMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRMS.Tests;
+
+public class Services_SmokeTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task EmployeeService_CanCreateAndRetrieveEmployee()
+    {
+        await using var context = CreateContext();
+        var departmentRepository = new GenericRepository<Department>(context);
+        var employeeRepository = new GenericRepository<Employee>(context);
+
+        IDepartmentService departmentService = new DepartmentService(departmentRepository);
+        var department = await departmentService.CreateAsync(new CreateDepartmentDto
+        {
+            Name = "Engineering"
+        });
+
+        IEmployeeService employeeService = new EmployeeService(employeeRepository, departmentRepository);
+        var createdEmployee = await employeeService.CreateAsync(new CreateEmployeeDto
+        {
+            EmpNo = "EMP001",
+            FullName = "Ada Lovelace",
+            Email = "ada@example.com",
+            DepartmentId = department.Id,
+            HireDate = new DateTime(2020, 1, 1)
+        });
+
+        Assert.NotNull(createdEmployee);
+        Assert.Equal("Ada Lovelace", createdEmployee.FullName);
+
+        var fetchedEmployee = await employeeService.GetByIdAsync(createdEmployee.Id);
+        Assert.NotNull(fetchedEmployee);
+        Assert.Equal(department.Name, fetchedEmployee!.DepartmentName);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ The data access project references the following EF Core packages:
 - `Microsoft.EntityFrameworkCore.SqlServer`
 - `Microsoft.EntityFrameworkCore.Design`
 - `Microsoft.EntityFrameworkCore.Tools`
+- `Microsoft.Extensions.Configuration`
+- `Microsoft.Extensions.Configuration.Abstractions`
+- `Microsoft.Extensions.Configuration.FileExtensions`
+- `Microsoft.Extensions.Configuration.Json`
+- `Microsoft.Extensions.Configuration.Binder`
+- `Microsoft.Extensions.Configuration.EnvironmentVariables`
+
+These dependencies keep the design-time context factory compiling without needing a local `appsettings.json`.
 
 ### Migrations
 Create or update migrations from the solution root (files only, no database update required):
@@ -31,6 +39,40 @@ dotnet ef migrations add <MigrationName> -p HRMS.DataAccess -s HRMS.API
 
 # Apply migrations to the configured database
 dotnet ef database update -p HRMS.DataAccess -s HRMS.API
+```
+
+## Services Layer (PR #4)
+- Added strongly-typed CRUD services for `Department`, `Employee`, and `LeaveBalance` that sit on top of the shared `IGenericRepository<T>` abstraction.
+- Services operate exclusively with DTOs (`Create*`, `Update*`, `PagedRequest`, `PagedResult<T>`) and include basic validation for identifiers, strings, email format, and non-negative leave balances.
+- `HRMS.API` now registers `IDepartmentService`, `IEmployeeService`, and `ILeaveBalanceService` alongside the existing DbContext/repository wiring.
+- `HRMS.Tests` includes an in-memory smoke test ensuring the service layer can create and fetch core entities.
+
+> ⚠️ **Developer note:** After pulling this PR, run `dotnet restore HRMS.sln` locally before the first build to regenerate `project.assets.json`.
+
+### Dependency Injection quick reference
+`Program.cs` wires up the services as scoped dependencies:
+
+```csharp
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+builder.Services.AddScoped<IDepartmentService, DepartmentService>();
+builder.Services.AddScoped<IEmployeeService, EmployeeService>();
+builder.Services.AddScoped<ILeaveBalanceService, LeaveBalanceService>();
+```
+
+### Example minimal API endpoint
+You can call the services from minimal API endpoints or controllers. For example, to fetch an employee by id:
+
+```csharp
+app.MapGet("/api/employees/{id:int}", async (int id, IEmployeeService employees, CancellationToken token) =>
+{
+    var employee = await employees.GetByIdAsync(id, token);
+    return employee is not null
+        ? Results.Ok(employee)
+        : Results.NotFound();
+});
 ```
 
 ## Running
@@ -53,28 +95,3 @@ Run tests:
 cd ../HRMS.Tests
 # dotnet test
 ```
-#### Manual Fixed  After merged DATA ACCESS EF Core
-
-DesignTimeDbContextFactory to compile:
-
-Installed NuGet packages (HRMS.DataAccess)
-
-Microsoft.Extensions.Configuration
-
-Microsoft.Extensions.Configuration.Abstractions
-
-Microsoft.Extensions.Configuration.FileExtensions
-
-Microsoft.Extensions.Configuration.Json
-
-Microsoft.Extensions.Configuration.Binder
-
-Microsoft.Extensions.Configuration.EnvironmentVariables  (needed for AddEnvironmentVariables())
-
-
-DesignTimeDbContextFactory.cs
-
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.Extensions.Configuration;
-using System.IO;


### PR DESCRIPTION
## Summary
- implement Department, Employee, and LeaveBalance services that sit on top of the shared generic repository, including DTO mapping, validation, and pagination support
- extend the DTO surface area with create/update models plus a reusable PagedRequest helper to keep the services contract DTO-only
- wire the new services into the API DI container, add an in-memory smoke test, and document the new layer plus usage guidance in the README

## Testing
- not run (per instructions to skip restore/build/test)

------
https://chatgpt.com/codex/tasks/task_e_68c9345ddab88333bdfb48716b1f21ef