### PR TITLE
feat: PR #5 – API controllers (CRUD endpoints, validation, DI wiring, tests scaffold)

### DIFF
--- a/HRMS.API/Controllers/ApiControllerBase.cs
+++ b/HRMS.API/Controllers/ApiControllerBase.cs
@@ -1,0 +1,50 @@
+using HRMS.Models.DTOs;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.API.Controllers;
+
+public abstract class ApiControllerBase : ControllerBase
+{
+    protected static PagedRequest? BuildPagedRequest(int? page, int? size, string? search)
+    {
+        var hasPagingParameters = page.HasValue || size.HasValue || !string.IsNullOrWhiteSpace(search);
+        if (!hasPagingParameters)
+        {
+            return null;
+        }
+
+        var request = new PagedRequest();
+
+        if (page.HasValue)
+        {
+            request.Page = page.Value;
+        }
+
+        if (size.HasValue)
+        {
+            request.PageSize = size.Value;
+        }
+
+        request.SearchTerm = string.IsNullOrWhiteSpace(search)
+            ? null
+            : search.Trim();
+
+        return request;
+    }
+
+    protected IActionResult HandleException(Exception exception)
+    {
+        return exception switch
+        {
+            InvalidOperationException invalidOperation when invalidOperation.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                => Problem(detail: invalidOperation.Message, statusCode: StatusCodes.Status404NotFound, title: "Not Found"),
+            ArgumentException argumentException
+                => Problem(detail: argumentException.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request"),
+            InvalidOperationException invalidOperation
+                => Problem(detail: invalidOperation.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request"),
+            _
+                => Problem(detail: "An unexpected error occurred.", statusCode: StatusCodes.Status500InternalServerError, title: "Server Error")
+        };
+    }
+}

--- a/HRMS.API/Controllers/DepartmentsController.cs
+++ b/HRMS.API/Controllers/DepartmentsController.cs
@@ -1,0 +1,88 @@
+using HRMS.Models.DTOs;
+using HRMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DepartmentsController : ApiControllerBase
+{
+    private readonly IDepartmentService _departmentService;
+
+    public DepartmentsController(IDepartmentService departmentService)
+    {
+        _departmentService = departmentService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAsync([FromQuery] int? page = null, [FromQuery(Name = "size")] int? size = null, [FromQuery] string? search = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = BuildPagedRequest(page, size, search);
+            var departments = await _departmentService.GetAsync(request, cancellationToken);
+            return Ok(departments);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var department = await _departmentService.GetByIdAsync(id, cancellationToken);
+            return department is not null ? Ok(department) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateAsync([FromBody] CreateDepartmentDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var created = await _departmentService.CreateAsync(dto, cancellationToken);
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = created.Id }, created);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> UpdateAsync([FromRoute] int id, [FromBody] UpdateDepartmentDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var updated = await _departmentService.UpdateAsync(id, dto, cancellationToken);
+            return updated is not null ? Ok(updated) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var deleted = await _departmentService.DeleteAsync(id, cancellationToken);
+            return deleted ? NoContent() : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+}

--- a/HRMS.API/Controllers/EmployeesController.cs
+++ b/HRMS.API/Controllers/EmployeesController.cs
@@ -1,0 +1,88 @@
+using HRMS.Models.DTOs;
+using HRMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class EmployeesController : ApiControllerBase
+{
+    private readonly IEmployeeService _employeeService;
+
+    public EmployeesController(IEmployeeService employeeService)
+    {
+        _employeeService = employeeService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAsync([FromQuery] int? page = null, [FromQuery(Name = "size")] int? size = null, [FromQuery] string? search = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = BuildPagedRequest(page, size, search);
+            var employees = await _employeeService.GetAsync(request, cancellationToken);
+            return Ok(employees);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var employee = await _employeeService.GetByIdAsync(id, cancellationToken);
+            return employee is not null ? Ok(employee) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateAsync([FromBody] CreateEmployeeDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var created = await _employeeService.CreateAsync(dto, cancellationToken);
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = created.Id }, created);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> UpdateAsync([FromRoute] int id, [FromBody] UpdateEmployeeDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var updated = await _employeeService.UpdateAsync(id, dto, cancellationToken);
+            return updated is not null ? Ok(updated) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var deleted = await _employeeService.DeleteAsync(id, cancellationToken);
+            return deleted ? NoContent() : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+}

--- a/HRMS.API/Controllers/LeaveBalancesController.cs
+++ b/HRMS.API/Controllers/LeaveBalancesController.cs
@@ -1,0 +1,88 @@
+using HRMS.Models.DTOs;
+using HRMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class LeaveBalancesController : ApiControllerBase
+{
+    private readonly ILeaveBalanceService _leaveBalanceService;
+
+    public LeaveBalancesController(ILeaveBalanceService leaveBalanceService)
+    {
+        _leaveBalanceService = leaveBalanceService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAsync([FromQuery] int? page = null, [FromQuery(Name = "size")] int? size = null, [FromQuery] string? search = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = BuildPagedRequest(page, size, search);
+            var balances = await _leaveBalanceService.GetAsync(request, cancellationToken);
+            return Ok(balances);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetByIdAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var balance = await _leaveBalanceService.GetByIdAsync(id, cancellationToken);
+            return balance is not null ? Ok(balance) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateAsync([FromBody] CreateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var created = await _leaveBalanceService.CreateAsync(dto, cancellationToken);
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = created.Id }, created);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> UpdateAsync([FromRoute] int id, [FromBody] UpdateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var updated = await _leaveBalanceService.UpdateAsync(id, dto, cancellationToken);
+            return updated is not null ? Ok(updated) : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteAsync([FromRoute] int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var deleted = await _leaveBalanceService.DeleteAsync(id, cancellationToken);
+            return deleted ? NoContent() : NotFound();
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return HandleException(ex);
+        }
+    }
+}

--- a/HRMS.API/HRMS.API.csproj
+++ b/HRMS.API/HRMS.API.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <ProjectReference Include="..\HRMS.Services\HRMS.Services.csproj" />
     <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
     <ProjectReference Include="..\HRMS.DataAccess\HRMS.DataAccess.csproj" />

--- a/HRMS.API/Program.cs
+++ b/HRMS.API/Program.cs
@@ -18,7 +18,19 @@ builder.Services.AddScoped<IDepartmentService, DepartmentService>();
 builder.Services.AddScoped<IEmployeeService, EmployeeService>();
 builder.Services.AddScoped<ILeaveBalanceService, LeaveBalanceService>();
 
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
 var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
 
 app.MapGet("/", () => "HRMS API");
 

--- a/HRMS.Tests/Controllers_SmokeTests.cs
+++ b/HRMS.Tests/Controllers_SmokeTests.cs
@@ -1,0 +1,240 @@
+using HRMS.API.Controllers;
+using HRMS.Models.DTOs;
+using HRMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.Tests;
+
+public class Controllers_SmokeTests
+{
+    [Fact]
+    public async Task DepartmentsController_Get_ReturnsOk()
+    {
+        var service = new StubDepartmentService();
+        var controller = new DepartmentsController(service);
+
+        var result = await controller.GetAsync(null, null, null, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<PagedResult<DepartmentDto>>(ok.Value);
+    }
+
+    [Fact]
+    public async Task EmployeesController_GetById_ReturnsNotFoundWhenMissing()
+    {
+        var service = new StubEmployeeService
+        {
+            GetByIdHandler = (id, token) => Task.FromResult<EmployeeDto?>(null)
+        };
+        var controller = new EmployeesController(service);
+
+        var result = await controller.GetByIdAsync(123, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task LeaveBalancesController_Create_ReturnsCreated()
+    {
+        var service = new StubLeaveBalanceService();
+        var controller = new LeaveBalancesController(service);
+        var dto = new CreateLeaveBalanceDto
+        {
+            EmpNo = "EMP001",
+            Annual = 10,
+            Sick = 5,
+            Unpaid = 0
+        };
+
+        var result = await controller.CreateAsync(dto, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result);
+        Assert.Equal(nameof(LeaveBalancesController.GetByIdAsync), created.ActionName);
+    }
+
+    private sealed class StubDepartmentService : IDepartmentService
+    {
+        public Func<PagedRequest?, CancellationToken, Task<PagedResult<DepartmentDto>>> GetHandler { get; set; }
+            = (request, token) => Task.FromResult(new PagedResult<DepartmentDto>
+            {
+                Items = new[] { new DepartmentDto { Id = 1, Name = "HR" } },
+                Total = 1,
+                Page = PagedRequest.DefaultPage,
+                PageSize = PagedRequest.DefaultPageSize
+            });
+
+        public Func<int, CancellationToken, Task<DepartmentDto?>> GetByIdHandler { get; set; }
+            = (id, token) => Task.FromResult<DepartmentDto?>(new DepartmentDto { Id = id, Name = "HR" });
+
+        public Func<CreateDepartmentDto, CancellationToken, Task<DepartmentDto>> CreateHandler { get; set; }
+            = (dto, token) => Task.FromResult(new DepartmentDto { Id = 1, Name = dto.Name });
+
+        public Func<int, UpdateDepartmentDto, CancellationToken, Task<DepartmentDto?>> UpdateHandler { get; set; }
+            = (id, dto, token) => Task.FromResult<DepartmentDto?>(new DepartmentDto { Id = id, Name = dto.Name });
+
+        public Func<int, CancellationToken, Task<bool>> DeleteHandler { get; set; }
+            = (id, token) => Task.FromResult(true);
+
+        public Task<PagedResult<DepartmentDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+            => GetHandler(request, cancellationToken);
+
+        public Task<DepartmentDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+            => GetByIdHandler(id, cancellationToken);
+
+        public Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto, CancellationToken cancellationToken = default)
+            => CreateHandler(dto, cancellationToken);
+
+        public Task<DepartmentDto?> UpdateAsync(int id, UpdateDepartmentDto dto, CancellationToken cancellationToken = default)
+            => UpdateHandler(id, dto, cancellationToken);
+
+        public Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+            => DeleteHandler(id, cancellationToken);
+    }
+
+    private sealed class StubEmployeeService : IEmployeeService
+    {
+        public Func<PagedRequest?, CancellationToken, Task<PagedResult<EmployeeDto>>> GetHandler { get; set; }
+            = (request, token) => Task.FromResult(new PagedResult<EmployeeDto>
+            {
+                Items = new[]
+                {
+                    new EmployeeDto
+                    {
+                        Id = 1,
+                        EmpNo = "EMP001",
+                        FullName = "Ada Lovelace",
+                        Email = "ada@example.com",
+                        DepartmentName = "Engineering",
+                        HireDate = new DateTime(2020, 1, 1)
+                    }
+                },
+                Total = 1,
+                Page = PagedRequest.DefaultPage,
+                PageSize = PagedRequest.DefaultPageSize
+            });
+
+        public Func<int, CancellationToken, Task<EmployeeDto?>> GetByIdHandler { get; set; }
+            = (id, token) => Task.FromResult<EmployeeDto?>(new EmployeeDto
+            {
+                Id = id,
+                EmpNo = "EMP001",
+                FullName = "Ada Lovelace",
+                Email = "ada@example.com",
+                DepartmentName = "Engineering",
+                HireDate = new DateTime(2020, 1, 1)
+            });
+
+        public Func<CreateEmployeeDto, CancellationToken, Task<EmployeeDto>> CreateHandler { get; set; }
+            = (dto, token) => Task.FromResult(new EmployeeDto
+            {
+                Id = 2,
+                EmpNo = dto.EmpNo,
+                FullName = dto.FullName,
+                Email = dto.Email,
+                DepartmentName = "Engineering",
+                HireDate = dto.HireDate
+            });
+
+        public Func<int, UpdateEmployeeDto, CancellationToken, Task<EmployeeDto?>> UpdateHandler { get; set; }
+            = (id, dto, token) => Task.FromResult<EmployeeDto?>(new EmployeeDto
+            {
+                Id = id,
+                EmpNo = "EMP001",
+                FullName = dto.FullName,
+                Email = dto.Email,
+                DepartmentName = "Engineering",
+                HireDate = dto.HireDate
+            });
+
+        public Func<int, CancellationToken, Task<bool>> DeleteHandler { get; set; }
+            = (id, token) => Task.FromResult(true);
+
+        public Task<PagedResult<EmployeeDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+            => GetHandler(request, cancellationToken);
+
+        public Task<EmployeeDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+            => GetByIdHandler(id, cancellationToken);
+
+        public Task<EmployeeDto> CreateAsync(CreateEmployeeDto dto, CancellationToken cancellationToken = default)
+            => CreateHandler(dto, cancellationToken);
+
+        public Task<EmployeeDto?> UpdateAsync(int id, UpdateEmployeeDto dto, CancellationToken cancellationToken = default)
+            => UpdateHandler(id, dto, cancellationToken);
+
+        public Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+            => DeleteHandler(id, cancellationToken);
+    }
+
+    private sealed class StubLeaveBalanceService : ILeaveBalanceService
+    {
+        public Func<PagedRequest?, CancellationToken, Task<PagedResult<LeaveBalanceDto>>> GetHandler { get; set; }
+            = (request, token) => Task.FromResult(new PagedResult<LeaveBalanceDto>
+            {
+                Items = new[]
+                {
+                    new LeaveBalanceDto
+                    {
+                        Id = 1,
+                        EmpNo = "EMP001",
+                        Annual = 10,
+                        Sick = 5,
+                        Unpaid = 0
+                    }
+                },
+                Total = 1,
+                Page = PagedRequest.DefaultPage,
+                PageSize = PagedRequest.DefaultPageSize
+            });
+
+        public Func<int, CancellationToken, Task<LeaveBalanceDto?>> GetByIdHandler { get; set; }
+            = (id, token) => Task.FromResult<LeaveBalanceDto?>(new LeaveBalanceDto
+            {
+                Id = id,
+                EmpNo = "EMP001",
+                Annual = 10,
+                Sick = 5,
+                Unpaid = 0
+            });
+
+        public Func<CreateLeaveBalanceDto, CancellationToken, Task<LeaveBalanceDto>> CreateHandler { get; set; }
+            = (dto, token) => Task.FromResult(new LeaveBalanceDto
+            {
+                Id = 3,
+                EmpNo = dto.EmpNo,
+                Annual = dto.Annual,
+                Sick = dto.Sick,
+                Unpaid = dto.Unpaid
+            });
+
+        public Func<int, UpdateLeaveBalanceDto, CancellationToken, Task<LeaveBalanceDto?>> UpdateHandler { get; set; }
+            = (id, dto, token) => Task.FromResult<LeaveBalanceDto?>(new LeaveBalanceDto
+            {
+                Id = id,
+                EmpNo = "EMP001",
+                Annual = dto.Annual,
+                Sick = dto.Sick,
+                Unpaid = dto.Unpaid
+            });
+
+        public Func<int, CancellationToken, Task<bool>> DeleteHandler { get; set; }
+            = (id, token) => Task.FromResult(true);
+
+        public Task<PagedResult<LeaveBalanceDto>> GetAsync(PagedRequest? request = null, CancellationToken cancellationToken = default)
+            => GetHandler(request, cancellationToken);
+
+        public Task<LeaveBalanceDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+            => GetByIdHandler(id, cancellationToken);
+
+        public Task<LeaveBalanceDto?> GetByEmployeeNumberAsync(string empNo, CancellationToken cancellationToken = default)
+            => Task.FromResult<LeaveBalanceDto?>(null);
+
+        public Task<LeaveBalanceDto> CreateAsync(CreateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+            => CreateHandler(dto, cancellationToken);
+
+        public Task<LeaveBalanceDto?> UpdateAsync(int id, UpdateLeaveBalanceDto dto, CancellationToken cancellationToken = default)
+            => UpdateHandler(id, dto, cancellationToken);
+
+        public Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+            => DeleteHandler(id, cancellationToken);
+    }
+}

--- a/HRMS.Tests/HRMS.Tests.csproj
+++ b/HRMS.Tests/HRMS.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\HRMS.Services\HRMS.Services.csproj" />
     <ProjectReference Include="..\HRMS.Models\HRMS.Models.csproj" />
     <ProjectReference Include="..\HRMS.DataAccess\HRMS.DataAccess.csproj" />
+    <ProjectReference Include="..\HRMS.API\HRMS.API.csproj" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,61 @@ app.MapGet("/api/employees/{id:int}", async (int id, IEmployeeService employees,
 });
 ```
 
+## PR #5 – API
+- Added `DepartmentsController`, `EmployeesController`, and `LeaveBalancesController` (all under `api/{controller}`) that expose paged list, lookup, create, update, and delete endpoints backed by the service layer.
+- Introduced a shared controller base to translate known service exceptions into RFC 7807 problem details and to normalize paging parameters.
+- Enabled Swagger (development-only) so the new endpoints can be discovered quickly during manual testing, and added controller smoke tests that exercise the CRUD endpoints with stubbed services.
+
+### Sample requests
+```http
+GET /api/employees?page=1&size=10
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "items": [
+    {
+      "id": 1,
+      "empNo": "EMP001",
+      "fullName": "Ada Lovelace",
+      "email": "ada@example.com",
+      "departmentName": "Engineering",
+      "hireDate": "2020-01-01T00:00:00"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "pageSize": 10
+}
+```
+
+```http
+POST /api/departments
+Content-Type: application/json
+
+{
+  "name": "People Operations"
+}
+```
+
+```http
+HTTP/1.1 201 Created
+Location: /api/departments/5
+Content-Type: application/json
+
+{
+  "id": 5,
+  "name": "People Operations"
+}
+```
+
+> ℹ️ Validation follows the service layer guardrails: input strings are trimmed and inspected with string-based `StringComparison` overloads (for example `email.Contains("@", StringComparison.Ordinal)`), identifier arguments must be positive integers, and invalid arguments return HTTP 400 with RFC 7807 payloads while missing entities return HTTP 404.
+
+> ⚠️ **Developer note:** After pulling this PR, run `dotnet restore HRMS.sln` locally before the first build to regenerate `project.assets.json`.
+
 ## Running
 
 Restore dependencies and run the projects:


### PR DESCRIPTION
## Summary
- add controllers for departments, employees, and leave balances with CRUD endpoints and consistent problem details responses
- introduce a shared API controller base for paging normalization and error mapping and enable Swagger in development
- scaffold controller smoke tests with stub services and document the new API surface in the README

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c978cd30d48333b5ea742c9c9b975a