### PR TITLE
Add employee and department CRUD pages

### DIFF
--- a/HRMS.UI/Controllers/DepartmentsController.cs
+++ b/HRMS.UI/Controllers/DepartmentsController.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HRMS.Models.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRMS.UI.Controllers;
+
+public class DepartmentsController : Controller
+{
+    private const string DepartmentsEndpoint = "api/departments";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public DepartmentsController(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync(DepartmentsEndpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            ViewData["ErrorMessage"] = "Unable to load departments at this time.";
+            return View(new PagedResult<DepartmentDto>());
+        }
+
+        var departments = await DeserializeAsync<PagedResult<DepartmentDto>>(response) ?? new PagedResult<DepartmentDto>();
+        return View(departments);
+    }
+
+    public async Task<IActionResult> Details(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{DepartmentsEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load department details.");
+        }
+
+        var department = await DeserializeAsync<DepartmentDto>(response);
+        return department is not null ? View(department) : NotFound();
+    }
+
+    public IActionResult Create() => View(new CreateDepartmentDto());
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(CreateDepartmentDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(dto);
+        }
+
+        var client = CreateClient();
+        var response = await client.PostAsJsonAsync(DepartmentsEndpoint, dto);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        ModelState.AddModelError(string.Empty, "Unable to create department.");
+        return View(dto);
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{DepartmentsEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load department for editing.");
+        }
+
+        var department = await DeserializeAsync<DepartmentDto>(response);
+        if (department is null)
+        {
+            return NotFound();
+        }
+
+        ViewBag.DepartmentId = department.Id;
+        var model = new UpdateDepartmentDto
+        {
+            Name = department.Name
+        };
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(int id, UpdateDepartmentDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            ViewBag.DepartmentId = id;
+            return View(dto);
+        }
+
+        var client = CreateClient();
+        var response = await client.PutAsJsonAsync($"{DepartmentsEndpoint}/{id}", dto);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        ModelState.AddModelError(string.Empty, "Unable to update department.");
+        ViewBag.DepartmentId = id;
+        return View(dto);
+    }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{DepartmentsEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load department for deletion.");
+        }
+
+        var department = await DeserializeAsync<DepartmentDto>(response);
+        if (department is null)
+        {
+            return NotFound();
+        }
+
+        if (TempData.ContainsKey("ErrorMessage"))
+        {
+            ViewData["ErrorMessage"] = TempData["ErrorMessage"];
+        }
+
+        return View(department);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var client = CreateClient();
+        var response = await client.DeleteAsync($"{DepartmentsEndpoint}/{id}");
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        TempData["ErrorMessage"] = "Unable to delete department.";
+        return RedirectToAction(nameof(Delete), new { id });
+    }
+
+    private HttpClient CreateClient() => _httpClientFactory.CreateClient("HRMSApi");
+
+    private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return string.IsNullOrWhiteSpace(content)
+            ? default
+            : JsonSerializer.Deserialize<T>(content, _jsonOptions);
+    }
+}

--- a/HRMS.UI/Controllers/EmployeesController.cs
+++ b/HRMS.UI/Controllers/EmployeesController.cs
@@ -1,0 +1,241 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using HRMS.Models.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace HRMS.UI.Controllers;
+
+public class EmployeesController : Controller
+{
+    private const string EmployeesEndpoint = "api/employees";
+    private const string DepartmentsEndpoint = "api/departments";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public EmployeesController(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync(EmployeesEndpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            ViewData["ErrorMessage"] = "Unable to load employees at this time.";
+            return View(new PagedResult<EmployeeDto>());
+        }
+
+        var employees = await DeserializeAsync<PagedResult<EmployeeDto>>(response) ?? new PagedResult<EmployeeDto>();
+        return View(employees);
+    }
+
+    public async Task<IActionResult> Details(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{EmployeesEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load employee details.");
+        }
+
+        var employee = await DeserializeAsync<EmployeeDto>(response);
+        return employee is not null ? View(employee) : NotFound();
+    }
+
+    public async Task<IActionResult> Create()
+    {
+        await PopulateDepartmentsAsync();
+        var model = new CreateEmployeeDto
+        {
+            HireDate = DateTime.Today
+        };
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(CreateEmployeeDto dto)
+    {
+        if (!ModelState.IsValid)
+        {
+            await PopulateDepartmentsAsync(dto.DepartmentId);
+            return View(dto);
+        }
+
+        var client = CreateClient();
+        var response = await client.PostAsJsonAsync(EmployeesEndpoint, dto);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        ModelState.AddModelError(string.Empty, "Unable to create employee.");
+        await PopulateDepartmentsAsync(dto.DepartmentId);
+        return View(dto);
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{EmployeesEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load employee for editing.");
+        }
+
+        var employee = await DeserializeAsync<EmployeeDto>(response);
+        if (employee is null)
+        {
+            return NotFound();
+        }
+
+        var departments = await FetchDepartmentsAsync();
+        var selectedDepartmentId = departments
+            .FirstOrDefault(d => string.Equals(d.Name, employee.DepartmentName, StringComparison.OrdinalIgnoreCase))?.Id;
+
+        ViewBag.Departments = new SelectList(departments, "Id", "Name", selectedDepartmentId);
+        ViewBag.EmployeeId = employee.Id;
+        ViewBag.EmpNo = employee.EmpNo;
+
+        var model = new UpdateEmployeeDto
+        {
+            FullName = employee.FullName,
+            Email = employee.Email,
+            DepartmentId = selectedDepartmentId ?? 0,
+            HireDate = employee.HireDate
+        };
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(int id, UpdateEmployeeDto dto, string? empNo)
+    {
+        if (!ModelState.IsValid)
+        {
+            await PopulateDepartmentsAsync(dto.DepartmentId);
+            ViewBag.EmployeeId = id;
+            ViewBag.EmpNo = empNo;
+            return View(dto);
+        }
+
+        var client = CreateClient();
+        var response = await client.PutAsJsonAsync($"{EmployeesEndpoint}/{id}", dto);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        ModelState.AddModelError(string.Empty, "Unable to update employee.");
+        await PopulateDepartmentsAsync(dto.DepartmentId);
+        ViewBag.EmployeeId = id;
+        ViewBag.EmpNo = empNo;
+        return View(dto);
+    }
+
+    public async Task<IActionResult> Delete(int id)
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync($"{EmployeesEndpoint}/{id}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return Problem("Unable to load employee for deletion.");
+        }
+
+        var employee = await DeserializeAsync<EmployeeDto>(response);
+        if (employee is null)
+        {
+            return NotFound();
+        }
+
+        if (TempData.ContainsKey("ErrorMessage"))
+        {
+            ViewData["ErrorMessage"] = TempData["ErrorMessage"];
+        }
+
+        return View(employee);
+    }
+
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var client = CreateClient();
+        var response = await client.DeleteAsync($"{EmployeesEndpoint}/{id}");
+
+        if (response.IsSuccessStatusCode)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        TempData["ErrorMessage"] = "Unable to delete employee.";
+        return RedirectToAction(nameof(Delete), new { id });
+    }
+
+    private HttpClient CreateClient() => _httpClientFactory.CreateClient("HRMSApi");
+
+    private async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return string.IsNullOrWhiteSpace(content)
+            ? default
+            : JsonSerializer.Deserialize<T>(content, _jsonOptions);
+    }
+
+    private async Task PopulateDepartmentsAsync(int? selectedId = null)
+    {
+        var departments = await FetchDepartmentsAsync();
+        ViewBag.Departments = new SelectList(departments, "Id", "Name", selectedId);
+    }
+
+    private async Task<List<DepartmentDto>> FetchDepartmentsAsync()
+    {
+        var client = CreateClient();
+        var response = await client.GetAsync(DepartmentsEndpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return new List<DepartmentDto>();
+        }
+
+        var pagedDepartments = await DeserializeAsync<PagedResult<DepartmentDto>>(response);
+        return pagedDepartments?.Items?.ToList() ?? new List<DepartmentDto>();
+    }
+}

--- a/HRMS.UI/Program.cs
+++ b/HRMS.UI/Program.cs
@@ -2,8 +2,28 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
 
+var apiBaseUrl = builder.Configuration.GetValue<string>("ApiSettings:BaseUrl");
+if (string.IsNullOrWhiteSpace(apiBaseUrl))
+{
+    throw new InvalidOperationException("API base URL is not configured.");
+}
+
+builder.Services.AddHttpClient("HRMSApi", client =>
+{
+    client.BaseAddress = new Uri(apiBaseUrl);
+});
+
 var app = builder.Build();
 
-app.MapDefaultControllerRoute();
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();

--- a/HRMS.UI/Views/Departments/Create.cshtml
+++ b/HRMS.UI/Views/Departments/Create.cshtml
@@ -1,0 +1,22 @@
+@model CreateDepartmentDto
+
+@{
+    ViewData["Title"] = "Create Department";
+}
+
+<h1 class="h3 mb-4">Create Department</h1>
+
+<form asp-action="Create" method="post" class="card shadow-sm">
+    <div class="card-body">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label"></label>
+            <input asp-for="Name" class="form-control" required />
+        </div>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <button type="submit" class="btn btn-primary">Create</button>
+    </div>
+</form>

--- a/HRMS.UI/Views/Departments/Delete.cshtml
+++ b/HRMS.UI/Views/Departments/Delete.cshtml
@@ -1,0 +1,28 @@
+@model DepartmentDto
+
+@{
+    ViewData["Title"] = "Delete Department";
+}
+
+<h1 class="h3 mb-4 text-danger">Delete Department</h1>
+
+@if (ViewData["ErrorMessage"] is string errorMessage)
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+
+<div class="card border-danger shadow-sm">
+    <div class="card-body">
+        <p class="fw-semibold">Are you sure you want to delete this department?</p>
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Name</dt>
+            <dd class="col-sm-9">@Model.Name</dd>
+        </dl>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <form asp-action="Delete" asp-route-id="@Model.Id" method="post" class="d-inline">
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    </div>
+</div>

--- a/HRMS.UI/Views/Departments/Details.cshtml
+++ b/HRMS.UI/Views/Departments/Details.cshtml
@@ -1,0 +1,21 @@
+@model DepartmentDto
+
+@{
+    ViewData["Title"] = "Department Details";
+}
+
+<h1 class="h3 mb-4">Department Details</h1>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Name</dt>
+            <dd class="col-sm-9">@Model.Name</dd>
+        </dl>
+    </div>
+</div>
+
+<div class="mt-4 d-flex gap-2">
+    <a class="btn btn-outline-primary" asp-action="Edit" asp-route-id="@Model.Id">Edit</a>
+    <a class="btn btn-outline-secondary" asp-action="Index">Back to List</a>
+</div>

--- a/HRMS.UI/Views/Departments/Edit.cshtml
+++ b/HRMS.UI/Views/Departments/Edit.cshtml
@@ -1,0 +1,23 @@
+@model UpdateDepartmentDto
+
+@{
+    ViewData["Title"] = "Edit Department";
+    int departmentId = ViewBag.DepartmentId is int value ? value : 0;
+}
+
+<h1 class="h3 mb-4">Edit Department</h1>
+
+<form asp-action="Edit" asp-route-id="@departmentId" method="post" class="card shadow-sm">
+    <div class="card-body">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+        <div class="mb-3">
+            <label asp-for="Name" class="form-label"></label>
+            <input asp-for="Name" class="form-control" required />
+        </div>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+    </div>
+</form>

--- a/HRMS.UI/Views/Departments/Index.cshtml
+++ b/HRMS.UI/Views/Departments/Index.cshtml
@@ -1,0 +1,50 @@
+@model PagedResult<DepartmentDto>
+
+@{
+    ViewData["Title"] = "Departments";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3 mb-0">Departments</h1>
+    <a class="btn btn-primary" asp-action="Create">Create Department</a>
+</div>
+
+@if (ViewData["ErrorMessage"] is string errorMessage)
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+
+@if (Model?.Items?.Any() == true)
+{
+    <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Name</th>
+                    <th class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var department in Model.Items)
+                {
+                    <tr>
+                        <td>@department.Name</td>
+                        <td class="text-end">
+                            <div class="btn-group btn-group-sm" role="group">
+                                <a class="btn btn-outline-secondary" asp-action="Details" asp-route-id="@department.Id">Details</a>
+                                <a class="btn btn-outline-primary" asp-action="Edit" asp-route-id="@department.Id">Edit</a>
+                                <a class="btn btn-outline-danger" asp-action="Delete" asp-route-id="@department.Id">Delete</a>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <div class="alert alert-info" role="alert">
+        No departments found.
+    </div>
+}

--- a/HRMS.UI/Views/Employees/Create.cshtml
+++ b/HRMS.UI/Views/Employees/Create.cshtml
@@ -1,0 +1,44 @@
+@model CreateEmployeeDto
+
+@{
+    ViewData["Title"] = "Create Employee";
+}
+
+<h1 class="h3 mb-4">Create Employee</h1>
+
+<form asp-action="Create" method="post" class="card shadow-sm">
+    <div class="card-body">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+        <div class="mb-3">
+            <label asp-for="EmpNo" class="form-label"></label>
+            <input asp-for="EmpNo" class="form-control" required />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="FullName" class="form-label"></label>
+            <input asp-for="FullName" class="form-control" required />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="Email" class="form-label"></label>
+            <input asp-for="Email" class="form-control" type="email" required />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="DepartmentId" class="form-label">Department</label>
+            <select asp-for="DepartmentId" asp-items="ViewBag.Departments" class="form-select" required>
+                <option value="">Select a department</option>
+            </select>
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="HireDate" class="form-label"></label>
+            <input asp-for="HireDate" class="form-control" type="date" required />
+        </div>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <button type="submit" class="btn btn-primary">Create</button>
+    </div>
+</form>

--- a/HRMS.UI/Views/Employees/Delete.cshtml
+++ b/HRMS.UI/Views/Employees/Delete.cshtml
@@ -1,0 +1,40 @@
+@model EmployeeDto
+
+@{
+    ViewData["Title"] = "Delete Employee";
+}
+
+<h1 class="h3 mb-4 text-danger">Delete Employee</h1>
+
+@if (ViewData["ErrorMessage"] is string errorMessage)
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+
+<div class="card border-danger shadow-sm">
+    <div class="card-body">
+        <p class="fw-semibold">Are you sure you want to delete this employee?</p>
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Employee No</dt>
+            <dd class="col-sm-9">@Model.EmpNo</dd>
+
+            <dt class="col-sm-3">Name</dt>
+            <dd class="col-sm-9">@Model.FullName</dd>
+
+            <dt class="col-sm-3">Email</dt>
+            <dd class="col-sm-9">@Model.Email</dd>
+
+            <dt class="col-sm-3">Department</dt>
+            <dd class="col-sm-9">@Model.DepartmentName</dd>
+
+            <dt class="col-sm-3">Hire Date</dt>
+            <dd class="col-sm-9">@Model.HireDate.ToString("D")</dd>
+        </dl>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <form asp-action="Delete" asp-route-id="@Model.Id" method="post" class="d-inline">
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    </div>
+</div>

--- a/HRMS.UI/Views/Employees/Details.cshtml
+++ b/HRMS.UI/Views/Employees/Details.cshtml
@@ -1,0 +1,33 @@
+@model EmployeeDto
+
+@{
+    ViewData["Title"] = "Employee Details";
+}
+
+<h1 class="h3 mb-4">Employee Details</h1>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Employee No</dt>
+            <dd class="col-sm-9">@Model.EmpNo</dd>
+
+            <dt class="col-sm-3">Name</dt>
+            <dd class="col-sm-9">@Model.FullName</dd>
+
+            <dt class="col-sm-3">Email</dt>
+            <dd class="col-sm-9">@Model.Email</dd>
+
+            <dt class="col-sm-3">Department</dt>
+            <dd class="col-sm-9">@Model.DepartmentName</dd>
+
+            <dt class="col-sm-3">Hire Date</dt>
+            <dd class="col-sm-9">@Model.HireDate.ToString("D")</dd>
+        </dl>
+    </div>
+</div>
+
+<div class="mt-4 d-flex gap-2">
+    <a class="btn btn-outline-primary" asp-action="Edit" asp-route-id="@Model.Id">Edit</a>
+    <a class="btn btn-outline-secondary" asp-action="Index">Back to List</a>
+</div>

--- a/HRMS.UI/Views/Employees/Edit.cshtml
+++ b/HRMS.UI/Views/Employees/Edit.cshtml
@@ -1,0 +1,47 @@
+@model UpdateEmployeeDto
+
+@{
+    ViewData["Title"] = "Edit Employee";
+    int employeeId = ViewBag.EmployeeId is int value ? value : 0;
+    string employeeNumber = ViewBag.EmpNo as string ?? string.Empty;
+}
+
+<h1 class="h3 mb-4">Edit Employee</h1>
+
+<form asp-action="Edit" asp-route-id="@employeeId" method="post" class="card shadow-sm">
+    <div class="card-body">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <input type="hidden" name="empNo" value="@employeeNumber" />
+
+        <div class="mb-3">
+            <label class="form-label">Employee No</label>
+            <input class="form-control" value="@employeeNumber" readonly />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="FullName" class="form-label"></label>
+            <input asp-for="FullName" class="form-control" required />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="Email" class="form-label"></label>
+            <input asp-for="Email" class="form-control" type="email" required />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="DepartmentId" class="form-label">Department</label>
+            <select asp-for="DepartmentId" asp-items="ViewBag.Departments" class="form-select" required>
+                <option value="">Select a department</option>
+            </select>
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="HireDate" class="form-label"></label>
+            <input asp-for="HireDate" class="form-control" type="date" required />
+        </div>
+    </div>
+    <div class="card-footer d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+    </div>
+</form>

--- a/HRMS.UI/Views/Employees/Index.cshtml
+++ b/HRMS.UI/Views/Employees/Index.cshtml
@@ -1,0 +1,58 @@
+@model PagedResult<EmployeeDto>
+
+@{
+    ViewData["Title"] = "Employees";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3 mb-0">Employees</h1>
+    <a class="btn btn-primary" asp-action="Create">Create Employee</a>
+</div>
+
+@if (ViewData["ErrorMessage"] is string errorMessage)
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+
+@if (Model?.Items?.Any() == true)
+{
+    <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Employee No</th>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Department</th>
+                    <th>Hire Date</th>
+                    <th class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var employee in Model.Items)
+                {
+                    <tr>
+                        <td>@employee.EmpNo</td>
+                        <td>@employee.FullName</td>
+                        <td>@employee.Email</td>
+                        <td>@employee.DepartmentName</td>
+                        <td>@employee.HireDate.ToString("d")</td>
+                        <td class="text-end">
+                            <div class="btn-group btn-group-sm" role="group">
+                                <a class="btn btn-outline-secondary" asp-action="Details" asp-route-id="@employee.Id">Details</a>
+                                <a class="btn btn-outline-primary" asp-action="Edit" asp-route-id="@employee.Id">Edit</a>
+                                <a class="btn btn-outline-danger" asp-action="Delete" asp-route-id="@employee.Id">Delete</a>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <div class="alert alert-info" role="alert">
+        No employees found.
+    </div>
+}

--- a/HRMS.UI/Views/Shared/_Layout.cshtml
+++ b/HRMS.UI/Views/Shared/_Layout.cshtml
@@ -17,7 +17,13 @@
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link" asp-controller="Home" asp-action="Index">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-controller="Employees" asp-action="Index">Employees</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-controller="Departments" asp-action="Index">Departments</a>
                         </li>
                     </ul>
                 </div>

--- a/HRMS.UI/Views/_ViewImports.cshtml
+++ b/HRMS.UI/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 @using HRMS.Models
+@using HRMS.Models.DTOs
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/HRMS.UI/appsettings.Development.json
+++ b/HRMS.UI/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ApiSettings": {
+    "BaseUrl": "https://localhost:7097/"
   }
 }

--- a/HRMS.UI/appsettings.json
+++ b/HRMS.UI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiSettings": {
+    "BaseUrl": "https://localhost:7097/"
+  }
 }


### PR DESCRIPTION
## Summary
- add MVC controllers that use the HRMS API to manage employees and departments
- scaffold Bootstrap-based views for employee and department CRUD workflows
- configure the UI to use the API base URL and expose navigation links for the new pages

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ca307d1ca48333a81397392b9834ca