### PR TITLE
Standardize Create/Edit flows across API & UI (named routes, TempData success, ProblemDetails)

### DIFF
--- a/HRMS.API/Controllers/ApiControllerBase.cs
+++ b/HRMS.API/Controllers/ApiControllerBase.cs
@@ -34,21 +34,26 @@ public abstract class ApiControllerBase : ControllerBase
         return request;
     }
 
-    protected IActionResult HandleException(Exception exception)
+    protected IActionResult HandleException(Exception ex)
     {
-        return exception switch
+        return ex switch
         {
-            InvalidOperationException invalidOperation when invalidOperation.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            InvalidOperationException invalidOperation when
+                (invalidOperation.Message?.Contains("not found", StringComparison.OrdinalIgnoreCase) ?? false)
                 => Problem(detail: invalidOperation.Message, statusCode: StatusCodes.Status404NotFound, title: "Not Found"),
-            InvalidOperationException invalidOperation when invalidOperation.Message.Contains("exist", StringComparison.OrdinalIgnoreCase)
-                or invalidOperation.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase)
+
+            InvalidOperationException invalidOperation when
+                (invalidOperation.Message?.Contains("exist", StringComparison.OrdinalIgnoreCase) ?? false)
+                || (invalidOperation.Message?.Contains("duplicate", StringComparison.OrdinalIgnoreCase) ?? false)
                 => Problem(detail: invalidOperation.Message, statusCode: StatusCodes.Status409Conflict, title: "Conflict"),
+
             ArgumentException argumentException
                 => Problem(detail: argumentException.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request"),
+
             InvalidOperationException invalidOperation
                 => Problem(detail: invalidOperation.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request"),
-            _
-                => Problem(detail: "An unexpected error occurred.", statusCode: StatusCodes.Status500InternalServerError, title: "Server Error")
+
+            _ => Problem(detail: "An unexpected error occurred.", statusCode: StatusCodes.Status500InternalServerError, title: "Server Error")
         };
     }
 

--- a/HRMS.API/Controllers/DepartmentsController.cs
+++ b/HRMS.API/Controllers/DepartmentsController.cs
@@ -1,6 +1,7 @@
 using HRMS.Models.DTOs;
 using HRMS.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace HRMS.API.Controllers;
 
@@ -9,10 +10,12 @@ namespace HRMS.API.Controllers;
 public class DepartmentsController : ApiControllerBase
 {
     private readonly IDepartmentService _departmentService;
+    private readonly ILogger<DepartmentsController> _logger;
 
-    public DepartmentsController(IDepartmentService departmentService)
+    public DepartmentsController(IDepartmentService departmentService, ILogger<DepartmentsController> logger)
     {
         _departmentService = departmentService;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -30,7 +33,7 @@ public class DepartmentsController : ApiControllerBase
         }
     }
 
-    [HttpGet("{id:int}")]
+    [HttpGet("{id:int}", Name = "GetDepartmentById")]
     public async Task<IActionResult> GetByIdAsync([FromRoute] int id, CancellationToken cancellationToken = default)
     {
         try
@@ -50,11 +53,11 @@ public class DepartmentsController : ApiControllerBase
         try
         {
             var created = await _departmentService.CreateAsync(dto, cancellationToken);
-            return CreatedAtAction(nameof(GetByIdAsync), new { id = created.Id }, created);
+            return CreatedAtRoute("GetDepartmentById", new { id = created.Id }, created);
         }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        catch (Exception ex)
         {
-            return HandleException(ex);
+            return HandleAndLogException(ex, _logger, "creating", "department");
         }
     }
 
@@ -66,9 +69,9 @@ public class DepartmentsController : ApiControllerBase
             var updated = await _departmentService.UpdateAsync(id, dto, cancellationToken);
             return updated is not null ? Ok(updated) : NotFound();
         }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        catch (Exception ex)
         {
-            return HandleException(ex);
+            return HandleAndLogException(ex, _logger, "updating", "department");
         }
     }
 

--- a/HRMS.API/Controllers/LeaveBalancesController.cs
+++ b/HRMS.API/Controllers/LeaveBalancesController.cs
@@ -1,6 +1,7 @@
 using HRMS.Models.DTOs;
 using HRMS.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace HRMS.API.Controllers;
 
@@ -9,10 +10,12 @@ namespace HRMS.API.Controllers;
 public class LeaveBalancesController : ApiControllerBase
 {
     private readonly ILeaveBalanceService _leaveBalanceService;
+    private readonly ILogger<LeaveBalancesController> _logger;
 
-    public LeaveBalancesController(ILeaveBalanceService leaveBalanceService)
+    public LeaveBalancesController(ILeaveBalanceService leaveBalanceService, ILogger<LeaveBalancesController> logger)
     {
         _leaveBalanceService = leaveBalanceService;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -30,7 +33,7 @@ public class LeaveBalancesController : ApiControllerBase
         }
     }
 
-    [HttpGet("{id:int}")]
+    [HttpGet("{id:int}", Name = "GetLeaveBalanceById")]
     public async Task<IActionResult> GetByIdAsync([FromRoute] int id, CancellationToken cancellationToken = default)
     {
         try
@@ -50,11 +53,11 @@ public class LeaveBalancesController : ApiControllerBase
         try
         {
             var created = await _leaveBalanceService.CreateAsync(dto, cancellationToken);
-            return CreatedAtAction(nameof(GetByIdAsync), new { id = created.Id }, created);
+            return CreatedAtRoute("GetLeaveBalanceById", new { id = created.Id }, created);
         }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        catch (Exception ex)
         {
-            return HandleException(ex);
+            return HandleAndLogException(ex, _logger, "creating", "leave balance");
         }
     }
 
@@ -66,9 +69,9 @@ public class LeaveBalancesController : ApiControllerBase
             var updated = await _leaveBalanceService.UpdateAsync(id, dto, cancellationToken);
             return updated is not null ? Ok(updated) : NotFound();
         }
-        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        catch (Exception ex)
         {
-            return HandleException(ex);
+            return HandleAndLogException(ex, _logger, "updating", "leave balance");
         }
     }
 

--- a/HRMS.Tests/Controllers_SmokeTests.cs
+++ b/HRMS.Tests/Controllers_SmokeTests.cs
@@ -2,6 +2,7 @@ using HRMS.API.Controllers;
 using HRMS.Models.DTOs;
 using HRMS.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace HRMS.Tests;
 
@@ -11,7 +12,8 @@ public class Controllers_SmokeTests
     public async Task DepartmentsController_Get_ReturnsOk()
     {
         var service = new StubDepartmentService();
-        var controller = new DepartmentsController(service);
+        var logger = NullLogger<DepartmentsController>.Instance;
+        var controller = new DepartmentsController(service, logger);
 
         var result = await controller.GetAsync(null, null, null, CancellationToken.None);
 
@@ -26,7 +28,10 @@ public class Controllers_SmokeTests
         {
             GetByIdHandler = (id, token) => Task.FromResult<EmployeeDto?>(null)
         };
-        var controller = new EmployeesController(service);
+
+
+        var logger = NullLogger<EmployeesController>.Instance;
+        var controller = new EmployeesController(service, logger);
 
         var result = await controller.GetByIdAsync(123, CancellationToken.None);
 
@@ -37,7 +42,8 @@ public class Controllers_SmokeTests
     public async Task LeaveBalancesController_Create_ReturnsCreated()
     {
         var service = new StubLeaveBalanceService();
-        var controller = new LeaveBalancesController(service);
+        var logger = NullLogger<LeaveBalancesController>.Instance;
+        var controller = new LeaveBalancesController(service,logger);
         var dto = new CreateLeaveBalanceDto
         {
             EmpNo = "EMP001",

--- a/HRMS.UI/Controllers/DepartmentsController.cs
+++ b/HRMS.UI/Controllers/DepartmentsController.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using HRMS.Models.DTOs;
+using HRMS.UI.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HRMS.UI.Controllers;
@@ -72,10 +73,11 @@ public class DepartmentsController : Controller
 
         if (response.IsSuccessStatusCode)
         {
+            TempData["Success"] = "Department saved successfully.";
             return RedirectToAction(nameof(Index));
         }
 
-        ModelState.AddModelError(string.Empty, "Unable to create department.");
+        await response.AddErrorsToModelStateAsync(ModelState, "department");
         return View(dto);
     }
 
@@ -124,10 +126,11 @@ public class DepartmentsController : Controller
 
         if (response.IsSuccessStatusCode)
         {
+            TempData["Success"] = "Department saved successfully.";
             return RedirectToAction(nameof(Index));
         }
 
-        ModelState.AddModelError(string.Empty, "Unable to update department.");
+        await response.AddErrorsToModelStateAsync(ModelState, "department");
         ViewBag.DepartmentId = id;
         return View(dto);
     }

--- a/HRMS.UI/Controllers/EmployeesController.cs
+++ b/HRMS.UI/Controllers/EmployeesController.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using HRMS.Models.DTOs;
+using HRMS.UI.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -84,10 +85,11 @@ public class EmployeesController : Controller
 
         if (response.IsSuccessStatusCode)
         {
+            TempData["Success"] = "Employee saved successfully.";
             return RedirectToAction(nameof(Index));
         }
 
-        ModelState.AddModelError(string.Empty, "Unable to create employee.");
+        await response.AddErrorsToModelStateAsync(ModelState, "employee");
         await PopulateDepartmentsAsync(dto.DepartmentId);
         return View(dto);
     }
@@ -149,10 +151,11 @@ public class EmployeesController : Controller
 
         if (response.IsSuccessStatusCode)
         {
+            TempData["Success"] = "Employee saved successfully.";
             return RedirectToAction(nameof(Index));
         }
 
-        ModelState.AddModelError(string.Empty, "Unable to update employee.");
+        await response.AddErrorsToModelStateAsync(ModelState, "employee");
         await PopulateDepartmentsAsync(dto.DepartmentId);
         ViewBag.EmployeeId = id;
         ViewBag.EmpNo = empNo;

--- a/HRMS.UI/Infrastructure/HttpResponseMessageExtensions.cs
+++ b/HRMS.UI/Infrastructure/HttpResponseMessageExtensions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace HRMS.UI.Infrastructure;
+
+public static class HttpResponseMessageExtensions
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static async Task AddErrorsToModelStateAsync(this HttpResponseMessage response, ModelStateDictionary modelState, string entityName)
+    {
+        if (response is null)
+        {
+            throw new ArgumentNullException(nameof(response));
+        }
+
+        if (modelState is null)
+        {
+            throw new ArgumentNullException(nameof(modelState));
+        }
+
+        var fallbackMessage = $"Unable to save {entityName}.";
+
+        try
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                modelState.AddModelError(string.Empty, fallbackMessage);
+                return;
+            }
+
+            var validation = JsonSerializer.Deserialize<ValidationProblemDetails>(content, JsonOptions);
+            if (validation?.Errors?.Count > 0)
+            {
+                foreach (var (key, errors) in validation.Errors)
+                {
+                    var targetKey = string.IsNullOrWhiteSpace(key) ? string.Empty : key;
+                    foreach (var error in errors)
+                    {
+                        modelState.AddModelError(targetKey, error);
+                    }
+                }
+
+                var summaryMessage = !string.IsNullOrWhiteSpace(validation.Detail)
+                    ? validation.Detail
+                    : validation.Title;
+
+                if (!string.IsNullOrWhiteSpace(summaryMessage))
+                {
+                    modelState.TryAddModelError(string.Empty, summaryMessage);
+                }
+
+                return;
+            }
+
+            var problem = JsonSerializer.Deserialize<ProblemDetails>(content, JsonOptions);
+            if (problem is not null)
+            {
+                var message = !string.IsNullOrWhiteSpace(problem.Detail)
+                    ? problem.Detail
+                    : problem.Title;
+
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    modelState.AddModelError(string.Empty, message);
+                }
+                else
+                {
+                    modelState.AddModelError(string.Empty, fallbackMessage);
+                }
+
+                return;
+            }
+
+            modelState.AddModelError(string.Empty, fallbackMessage);
+        }
+        catch (JsonException)
+        {
+            modelState.AddModelError(string.Empty, fallbackMessage);
+        }
+    }
+}

--- a/HRMS.UI/Views/Departments/Create.cshtml
+++ b/HRMS.UI/Views/Departments/Create.cshtml
@@ -8,11 +8,17 @@
 
 <form asp-action="Create" method="post" class="card shadow-sm">
     <div class="card-body">
-        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="alert alert-danger" role="alert">
+                <div asp-validation-summary="All"></div>
+            </div>
+        }
 
         <div class="mb-3">
             <label asp-for="Name" class="form-label"></label>
             <input asp-for="Name" class="form-control" required />
+            <span asp-validation-for="Name" class="text-danger"></span>
         </div>
     </div>
     <div class="card-footer d-flex justify-content-end gap-2">
@@ -20,3 +26,7 @@
         <button type="submit" class="btn btn-primary">Create</button>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/HRMS.UI/Views/Departments/Edit.cshtml
+++ b/HRMS.UI/Views/Departments/Edit.cshtml
@@ -9,11 +9,17 @@
 
 <form asp-action="Edit" asp-route-id="@departmentId" method="post" class="card shadow-sm">
     <div class="card-body">
-        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="alert alert-danger" role="alert">
+                <div asp-validation-summary="All"></div>
+            </div>
+        }
 
         <div class="mb-3">
             <label asp-for="Name" class="form-label"></label>
             <input asp-for="Name" class="form-control" required />
+            <span asp-validation-for="Name" class="text-danger"></span>
         </div>
     </div>
     <div class="card-footer d-flex justify-content-end gap-2">
@@ -21,3 +27,7 @@
         <button type="submit" class="btn btn-primary">Save Changes</button>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/HRMS.UI/Views/Departments/Index.cshtml
+++ b/HRMS.UI/Views/Departments/Index.cshtml
@@ -9,6 +9,11 @@
     <a class="btn btn-primary" asp-action="Create">Create Department</a>
 </div>
 
+@if (TempData["Success"] is string successMessage && !string.IsNullOrWhiteSpace(successMessage))
+{
+    <div class="alert alert-success" role="alert">@successMessage</div>
+}
+
 @if (ViewData["ErrorMessage"] is string errorMessage)
 {
     <div class="alert alert-danger" role="alert">@errorMessage</div>

--- a/HRMS.UI/Views/Employees/Create.cshtml
+++ b/HRMS.UI/Views/Employees/Create.cshtml
@@ -8,21 +8,29 @@
 
 <form asp-action="Create" method="post" class="card shadow-sm">
     <div class="card-body">
-        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="alert alert-danger" role="alert">
+                <div asp-validation-summary="All"></div>
+            </div>
+        }
 
         <div class="mb-3">
             <label asp-for="EmpNo" class="form-label"></label>
             <input asp-for="EmpNo" class="form-control" required />
+            <span asp-validation-for="EmpNo" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
             <label asp-for="FullName" class="form-label"></label>
             <input asp-for="FullName" class="form-control" required />
+            <span asp-validation-for="FullName" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
             <label asp-for="Email" class="form-label"></label>
             <input asp-for="Email" class="form-control" type="email" required />
+            <span asp-validation-for="Email" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
@@ -30,11 +38,13 @@
             <select asp-for="DepartmentId" asp-items="ViewBag.Departments" class="form-select" required>
                 <option value="">Select a department</option>
             </select>
+            <span asp-validation-for="DepartmentId" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
             <label asp-for="HireDate" class="form-label"></label>
             <input asp-for="HireDate" class="form-control" type="date" required />
+            <span asp-validation-for="HireDate" class="text-danger"></span>
         </div>
     </div>
     <div class="card-footer d-flex justify-content-end gap-2">
@@ -42,3 +52,7 @@
         <button type="submit" class="btn btn-primary">Create</button>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/HRMS.UI/Views/Employees/Edit.cshtml
+++ b/HRMS.UI/Views/Employees/Edit.cshtml
@@ -10,7 +10,12 @@
 
 <form asp-action="Edit" asp-route-id="@employeeId" method="post" class="card shadow-sm">
     <div class="card-body">
-        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="alert alert-danger" role="alert">
+                <div asp-validation-summary="All"></div>
+            </div>
+        }
         <input type="hidden" name="empNo" value="@employeeNumber" />
 
         <div class="mb-3">
@@ -21,11 +26,13 @@
         <div class="mb-3">
             <label asp-for="FullName" class="form-label"></label>
             <input asp-for="FullName" class="form-control" required />
+            <span asp-validation-for="FullName" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
             <label asp-for="Email" class="form-label"></label>
             <input asp-for="Email" class="form-control" type="email" required />
+            <span asp-validation-for="Email" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
@@ -33,11 +40,13 @@
             <select asp-for="DepartmentId" asp-items="ViewBag.Departments" class="form-select" required>
                 <option value="">Select a department</option>
             </select>
+            <span asp-validation-for="DepartmentId" class="text-danger"></span>
         </div>
 
         <div class="mb-3">
             <label asp-for="HireDate" class="form-label"></label>
             <input asp-for="HireDate" class="form-control" type="date" required />
+            <span asp-validation-for="HireDate" class="text-danger"></span>
         </div>
     </div>
     <div class="card-footer d-flex justify-content-end gap-2">
@@ -45,3 +54,7 @@
         <button type="submit" class="btn btn-primary">Save Changes</button>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/HRMS.UI/Views/Employees/Index.cshtml
+++ b/HRMS.UI/Views/Employees/Index.cshtml
@@ -9,6 +9,11 @@
     <a class="btn btn-primary" asp-action="Create">Create Employee</a>
 </div>
 
+@if (TempData["Success"] is string successMessage && !string.IsNullOrWhiteSpace(successMessage))
+{
+    <div class="alert alert-success" role="alert">@successMessage</div>
+}
+
 @if (ViewData["ErrorMessage"] is string errorMessage)
 {
     <div class="alert alert-danger" role="alert">@errorMessage</div>

--- a/HRMS.UI/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/HRMS.UI/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,3 @@
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation-unobtrusive@3.2.12/dist/jquery.validate.unobtrusive.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- give each entity controller a named GET-by-id route, switch POST actions to CreatedAtRoute, and add ProblemDetails logging/handling for predictable API responses
- introduce an HttpResponseMessage extension for parsing RFC7807 payloads so UI controllers can surface API validation, plus set TempData success messages before redirects
- hide empty validation banners, show success alerts on index pages, and add a shared validation scripts partial for consistent client-side validation

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a9f1d408333a7478b7610520ba5